### PR TITLE
Add Sourcey

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 * [Crosspost](https://trycrosspost.com) - Crosspost helps you write, import and publish articles to multiple platforms like Medium, Ghost, Hashnode, Dev.to and more at once. Write once, publish everywhere.
 * [Heroshot](https://github.com/omachala/heroshot) - Screenshot automation for documentation with a visual element picker and theme-aware output.
 * [EkLine](https://ekline.io) - Documentation quality automation. Enforces style guides on PRs, validates links, flags outdated content, and helps draft new docs.
+* [Sourcey](https://sourcey.com) - Open source documentation platform for OpenAPI specs and markdown.
 
 ## Resources
 


### PR DESCRIPTION
Adds Sourcey — open source documentation platform that generates static sites from OpenAPI specs and markdown.

https://sourcey.com
https://github.com/sourcey/sourcey