### PR TITLE
Add unslop to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@
 * [Crosspost](https://trycrosspost.com) - Crosspost helps you write, import and publish articles to multiple platforms like Medium, Ghost, Hashnode, Dev.to and more at once. Write once, publish everywhere.
 * [Heroshot](https://github.com/omachala/heroshot) - Screenshot automation for documentation with a visual element picker and theme-aware output.
 * [EkLine](https://ekline.io) - Documentation quality automation. Enforces style guides on PRs, validates links, flags outdated content, and helps draft new docs.
-* [unslop](https://github.com/MohamedAbdallah-14/unslop) - A Claude Code plugin that removes AI writing patterns from text — tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary. Five intensity levels. Detection and rewriting are split so you can run it as a lint pass on your own writing. MIT licensed.
+* [unslop](https://github.com/MohamedAbdallah-14/unslop) - A Claude Code plugin that removes AI writing patterns from text — tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 * [Crosspost](https://trycrosspost.com) - Crosspost helps you write, import and publish articles to multiple platforms like Medium, Ghost, Hashnode, Dev.to and more at once. Write once, publish everywhere.
 * [Heroshot](https://github.com/omachala/heroshot) - Screenshot automation for documentation with a visual element picker and theme-aware output.
 * [EkLine](https://ekline.io) - Documentation quality automation. Enforces style guides on PRs, validates links, flags outdated content, and helps draft new docs.
+* [unslop](https://github.com/MohamedAbdallah-14/unslop) - A Claude Code plugin that removes AI writing patterns from text — tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary. Five intensity levels. Detection and rewriting are split so you can run it as a lint pass on your own writing. MIT licensed.
 
 ## Resources
 


### PR DESCRIPTION
Adds [unslop](https://github.com/MohamedAbdallah-14/unslop) to the **Useful Tools** section.

**What it does:** A Claude Code plugin that removes AI writing patterns from text — tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary, performative balance, and similar tells. Directly useful for technical writers who use LLMs for drafts and need to remove AI-isms before publishing.

**Key features:**
- Five intensity levels (subtle → balanced → full → voice-match → anti-detector)  
- Detection and rewriting are split — run detection-only as a lint pass on your own writing
- Pattern-based approach targeting readable prose, not detector scores
- MIT licensed, no SaaS, no auth