### PR TITLE
Add NRG to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 * [Crosspost](https://trycrosspost.com) - Crosspost helps you write, import and publish articles to multiple platforms like Medium, Ghost, Hashnode, Dev.to and more at once. Write once, publish everywhere.
 * [Heroshot](https://github.com/omachala/heroshot) - Screenshot automation for documentation with a visual element picker and theme-aware output.
 * [EkLine](https://ekline.io) - Documentation quality automation. Enforces style guides on PRs, validates links, flags outdated content, and helps draft new docs.
+* [NRG](https://github.com/nanolaba/readme-generator) - Multi-language README generator with widgets (CLI, Maven plugin, Java library).
 
 ## Resources
 


### PR DESCRIPTION
Adds [NRG](https://github.com/nanolaba/readme-generator) — a small Java tool that generates one README per language from a single `.src.md` template (CLI + Maven plugin + library). Useful for technical writers maintaining bi/multilingual project docs without copy-paste drift between language versions.