### PR TITLE
Add slop-gate to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 * [Crosspost](https://trycrosspost.com) - Crosspost helps you write, import and publish articles to multiple platforms like Medium, Ghost, Hashnode, Dev.to and more at once. Write once, publish everywhere.
 * [Heroshot](https://github.com/omachala/heroshot) - Screenshot automation for documentation with a visual element picker and theme-aware output.
 * [EkLine](https://ekline.io) - Documentation quality automation. Enforces style guides on PRs, validates links, flags outdated content, and helps draft new docs.
+* [Slop-Gate](https://github.com/hwajongpark/slop-gate) - CLI that flags AI writing-tells (em-dashes and filler words like "delve" and "seamless") in prose before you publish, locally or in CI.
 
 ## Resources
 


### PR DESCRIPTION
Adds [slop-gate](https://github.com/hwajongpark/slop-gate) under Useful Tools.

A zero-dependency CLI that flags AI writing-tells (em-dashes plus ~40 filler vocabulary tells like "delve" and "seamless") in prose before publishing, with a path allowlist; runs locally or in CI. Useful for technical writers and docs teams keeping copy clean. MIT licensed.

Format follows the Useful Tools convention: `* [name](link) - Description.`