### PR TITLE
Add workflow to auto add contributors on PR merge

### DIFF
--- a/.github/workflows/auto-add-contributor.yml
+++ b/.github/workflows/auto-add-contributor.yml
@@ -1,0 +1,15 @@
+name: Auto Add Contributor
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  add-contributor:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: plbstl/first-contribution@main
+        with:
+          pr-merged-msg: >
+            @all-contributors please add @{fc-author} for docs


### PR DESCRIPTION
This workflow automatically adds contributors when a pull request is merged.

#### What does this PR add

#### Description of added resource
