### PR TITLE
Add Excel to Markdown to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@
 * [Who Pays Technical Writers?](https://whopaystechnicalwriters.com/?) - A curated collection of active publishers, publications, and agencies that pay fair rates for high-quality technical content.
 * [Diátaxis Documentation System](https://diataxis.fr) - A systematic approach to creating better documentation.
 * [HackMD](https://hackmd.io) - Real-time collaboration on technical documentation in Markdown.
-* [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Convert Excel, CSV, or pasted tables into Markdown locally in the browser.
 * [Dropbox Paper](https://dropbox.com/paper) - A flexible workspace for collaborative document editing.
 * [Google Docs](https://docs.google.com) - Smart editing and styling tools to help you easily format text and paragraphs.
 * [Notion](https://notion.so) - The all-in-one workspace for your notes, tasks, wikis and databases.
@@ -163,6 +162,7 @@
 * [JustBlogged](https://justblogged.com) - A no-setup blogging platform with built-in SEO, custom domains, and beautiful themes. Sign up, pick a name, and start publishing technical content in minutes.
 * [ProseScore](https://prosescore.ckmtools.dev/) - Free browser-based readability analyser with 8 formulas, sentiment analysis, keyword extraction, and SEO scoring. Privacy-first, runs entirely client-side.
 * [Patina](https://github.com/devswha/patina) - Audits and rewrites AI-sounding technical writing while preserving meaning, claims, numbers, polarity, and causation.
+* [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Convert Excel, CSV, or pasted tables into Markdown locally in the browser.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@
 * [Who Pays Technical Writers?](https://whopaystechnicalwriters.com/?) - A curated collection of active publishers, publications, and agencies that pay fair rates for high-quality technical content.
 * [Diátaxis Documentation System](https://diataxis.fr) - A systematic approach to creating better documentation.
 * [HackMD](https://hackmd.io) - Real-time collaboration on technical documentation in Markdown.
+* [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Convert Excel, CSV, or pasted tables into Markdown locally in the browser.
 * [Dropbox Paper](https://dropbox.com/paper) - A flexible workspace for collaborative document editing.
 * [Google Docs](https://docs.google.com) - Smart editing and styling tools to help you easily format text and paragraphs.
 * [Notion](https://notion.so) - The all-in-one workspace for your notes, tasks, wikis and databases.


### PR DESCRIPTION
Adds one browser-local table conversion utility to the Useful Tools section. Excel to Markdown helps technical writers turn XLSX, XLS, CSV, or pasted spreadsheet cells into Markdown tables without uploading source files.

Resource: https://exceltomd.com/excel-to-markdown

Disclosure: I built and operate Excel to Markdown.